### PR TITLE
FT - Add pressedSearch prop to CampusMap and update routing logic

### DIFF
--- a/expo-app/app/components/CampusMap/CampusMap.tsx
+++ b/expo-app/app/components/CampusMap/CampusMap.tsx
@@ -38,10 +38,11 @@ import { getFillColorWithOpacity } from "@/app/utils/helperFunctions";
 import IndoorMap from "@/app/components/IndoorNavigation/IndoorMap";
 
 interface CampusMapProps {
-  pressedOptimizeRoute: boolean;
+  pressedOptimizeRoute?: boolean;
+  pressedSearch?: boolean;
 }
 
-const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
+const CampusMap = ({ pressedOptimizeRoute = false, pressedSearch = false }: CampusMapProps) => {
   const [campus, setCampus] = useState<Campus>("SGW");
   const [routeCoordinates, setRouteCoordinates] = useState<Coordinates[]>([]);
   const [userLocation, setUserLocation] = useState<Coordinates | null>(null);
@@ -171,10 +172,13 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
   }, [selectedDistance, userLocation, fetchedPlaceResults]);
 
   useEffect(() => {
+    // Allows for routing from HomePageScreen to CampusMapScreen
     if (pressedOptimizeRoute) {
       setIsNextClassModalVisible(true);
+    } else if (pressedSearch) {
+      setIsSearchModalVisible(true);
     }
-  }, [pressedOptimizeRoute]);
+  }, [pressedOptimizeRoute, pressedSearch]);
 
   const handleMarkerPress = useCallback((marker: CustomMarkerType) => {
     const markerToBuilding: Building = {
@@ -292,10 +296,7 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
       if (indoorCapableBuildings.includes(destination.building.id)) {
         setIsIndoorMapVisible(true);
       } else {
-        Alert.alert(
-          "Indoor Map Not Available",
-          "Indoor map is not available for this building."
-        );
+        Alert.alert("Indoor Map Not Available", "Indoor map is not available for this building.");
       }
     } else {
       Alert.alert(
@@ -304,7 +305,7 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
       );
     }
   };
-  
+
   return (
     <View style={styles.container}>
       <HamburgerWidget
@@ -516,7 +517,10 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
         onRequestClose={() => setIsIndoorMapVisible(false)}
       >
         <View style={{ flex: 1 }}>
-          <IndoorMap indoorBuildingId={destination?.building?.id}  destinationRoom={destination?.room} />
+          <IndoorMap
+            indoorBuildingId={destination?.building?.id}
+            destinationRoom={destination?.room}
+          />
           <TouchableOpacity
             onPress={() => setIsIndoorMapVisible(false)}
             style={styles.closeIndoorMapButton}

--- a/expo-app/app/components/CampusMap/__tests__/CampusMap.test.tsx
+++ b/expo-app/app/components/CampusMap/__tests__/CampusMap.test.tsx
@@ -541,9 +541,14 @@ describe("Additional Modals and Components", () => {
     const { getByTestId } = render(<CampusMap pressedOptimizeRoute={true} />);
 
     await waitFor(() => {
-      // Check if search modal is automatically opened
       expect(getByTestId("next-class-modal-overlay")).toBeTruthy();
-      // Or check if any other optimize route behavior is triggered
+    });
+  });
+
+  it("should open search modal when pressedSearch is true", async () => {
+    const { getByTestId } = render(<CampusMap pressedSearch={true} />);
+    await waitFor(() => {
+      expect(getByTestId("search-modal")).toBeTruthy();
     });
   });
 });

--- a/expo-app/app/components/SearchBar/SearchBar.tsx
+++ b/expo-app/app/components/SearchBar/SearchBar.tsx
@@ -2,9 +2,10 @@ import React, { useState } from "react";
 import { View, TextInput, StyleSheet } from "react-native";
 import { Feather } from "@expo/vector-icons"; // Search icon
 import { useTranslation } from "react-i18next"; // Translation
+import { useRouter } from "expo-router";
 
 export default function SearchBar() {
-
+  const router = useRouter();
   const { t } = useTranslation("HomePageScreen");
 
   const [searchText, setSearchText] = useState("");
@@ -18,12 +19,19 @@ export default function SearchBar() {
         style={styles.searchInput}
         testID="search-input"
         value={searchText} // Controlled input
-        onChangeText={setSearchText} // Updates state on change
+        onChangeText={setSearchText} // Updates state on change}
+        onFocus={() =>
+          router.push({
+            pathname: "/screens/Home/CampusMapScreen",
+            params: {
+              pressedSearch: "true",
+            },
+          })
+        } 
       />
     </View>
   );
 }
-
 
 const styles = StyleSheet.create({
   searchContainer: {

--- a/expo-app/app/components/SearchBar/__tests__/SearchBar.test.tsx
+++ b/expo-app/app/components/SearchBar/__tests__/SearchBar.test.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react-native";
 import SearchBar from "../SearchBar"; 
+import {useRouter} from "expo-router"; 
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(),
+}));
 
 describe("SearchBar Component", () => {
   it("renders the search input field", () => {
@@ -20,5 +25,22 @@ describe("SearchBar Component", () => {
     fireEvent.changeText(searchInput, "Coffee Shop");
 
     expect(searchInput.props.value).toBe("Coffee Shop"); 
+  });
+
+  it("navigates to CampusMapScreen on focus", () => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    const { getByTestId } = render(<SearchBar />);
+    const searchInput = getByTestId("search-input");
+
+    fireEvent(searchInput, "focus"); // Simulate focus event
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/screens/Home/CampusMapScreen",
+      params: {
+        pressedSearch: "true",
+      },
+    });
   });
 });

--- a/expo-app/app/screens/Home/CampusMapScreen.tsx
+++ b/expo-app/app/screens/Home/CampusMapScreen.tsx
@@ -7,7 +7,7 @@ import CampusMap from "../../components/CampusMap/CampusMap";
 
 export default function CampusMapScreen() {
   const router = useRouter();
-  const { pressedOptimizeRoute } = useLocalSearchParams();
+  const { pressedOptimizeRoute, pressedSearch } = useLocalSearchParams();
 
   return (
     <View style={styles.container}>
@@ -22,7 +22,7 @@ export default function CampusMapScreen() {
 
       {/* Outdoor Campus Map Content */}
       <View style={styles.mapContainer}>
-        <CampusMap pressedOptimizeRoute={pressedOptimizeRoute === "true"} />
+        <CampusMap pressedOptimizeRoute={pressedOptimizeRoute === "true"} pressedSearch={pressedSearch==="true"} />
       </View>
     </View>
   );


### PR DESCRIPTION
This pull request includes several changes to the `CampusMap` component and related files to add a new feature for handling search functionality and improve the code readability.

### New Feature: Search Functionality

* [`expo-app/app/components/CampusMap/CampusMap.tsx`](diffhunk://#diff-86169344f1e74e761ef29fd8aa97feed5066b6dacf18af52166bb337ac20ddbdL41-R45): Added a new optional prop `pressedSearch` to handle the search modal visibility. Updated the `useEffect` hook to show the search modal when `pressedSearch` is true. [[1]](diffhunk://#diff-86169344f1e74e761ef29fd8aa97feed5066b6dacf18af52166bb337ac20ddbdL41-R45) [[2]](diffhunk://#diff-86169344f1e74e761ef29fd8aa97feed5066b6dacf18af52166bb337ac20ddbdR175-R181)

* [`expo-app/app/components/SearchBar/SearchBar.tsx`](diffhunk://#diff-302a37d0f79243b14fb373cbcd8d92d60ca04a708a4251753abfcb20d1853018R5-R8): Integrated the `useRouter` hook to navigate to `CampusMapScreen` with the `pressedSearch` parameter when the search input is focused. [[1]](diffhunk://#diff-302a37d0f79243b14fb373cbcd8d92d60ca04a708a4251753abfcb20d1853018R5-R8) [[2]](diffhunk://#diff-302a37d0f79243b14fb373cbcd8d92d60ca04a708a4251753abfcb20d1853018L21-L27)

* [`expo-app/app/screens/Home/CampusMapScreen.tsx`](diffhunk://#diff-7179987ad0c7638635950c1e3d0c29129a5091207444d9c4755ec1fb66beccafL10-R10): Updated the component to pass the `pressedSearch` parameter to `CampusMap`. [[1]](diffhunk://#diff-7179987ad0c7638635950c1e3d0c29129a5091207444d9c4755ec1fb66beccafL10-R10) [[2]](diffhunk://#diff-7179987ad0c7638635950c1e3d0c29129a5091207444d9c4755ec1fb66beccafL25-R25)

### Code Readability Improvements

* [`expo-app/app/components/CampusMap/CampusMap.tsx`](diffhunk://#diff-86169344f1e74e761ef29fd8aa97feed5066b6dacf18af52166bb337ac20ddbdL295-R299): Reformatted the alert message for better readability.

* [`expo-app/app/components/CampusMap/CampusMap.tsx`](diffhunk://#diff-86169344f1e74e761ef29fd8aa97feed5066b6dacf18af52166bb337ac20ddbdL519-R523): Reformatted the `IndoorMap` component for better readability.

### Testing

* [`expo-app/app/components/CampusMap/__tests__/CampusMap.test.tsx`](diffhunk://#diff-342878b460584408db83ccdd614bdd1cddc619ac1cf29c61bdb615262d26be21L544-R551): Added a new test case to verify that the search modal opens when `pressedSearch` is true.