### PR TITLE
US - Adding a Usability Testing Toggle

### DIFF
--- a/expo-app/app.json
+++ b/expo-app/app.json
@@ -57,6 +57,7 @@
       "typedRoutes": true
     },
     "extra": {
+      "clarityProjectId": "qtckqvmd75",
       "googleMapsApiKey": "AIzaSyBYvb6Sg2jIbSgu_ckcLfsUekS2-pS5mc8",
       "mappedInApiKey": "mik_LUeYSdqlvDJYpSHXT56b207a8",
       "mappedInSecret" : "mis_toNhLLj9mmlK5rJzJHebi3km4rjI9V3x3VUzgpPCYbq9a2410c7",

--- a/expo-app/app/index.tsx
+++ b/expo-app/app/index.tsx
@@ -12,6 +12,9 @@ import { useRouter } from "expo-router";
 import Svg, { Circle } from "react-native-svg";
 import { AuthContext } from "./contexts/AuthContext";
 import { useTranslation } from "react-i18next";
+import { initialize } from '@microsoft/react-native-clarity';
+
+initialize("qtckqvmd75");
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 

--- a/expo-app/app/index.tsx
+++ b/expo-app/app/index.tsx
@@ -12,9 +12,6 @@ import { useRouter } from "expo-router";
 import Svg, { Circle } from "react-native-svg";
 import { AuthContext } from "./contexts/AuthContext";
 import { useTranslation } from "react-i18next";
-import { initialize } from '@microsoft/react-native-clarity';
-
-initialize("qtckqvmd75");
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 

--- a/expo-app/app/screens/Settings/SettingsScreen.tsx
+++ b/expo-app/app/screens/Settings/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { View, ScrollView, Text, TouchableOpacity, StyleSheet, Switch } from "react-native";
+import { View, ScrollView, Text, TouchableOpacity, StyleSheet, Switch, Alert } from "react-native";
 import { useRouter } from "expo-router";
 import { FontAwesome5 } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -24,6 +24,7 @@ export default function SettingsScreen() {
       try {
         const savedNotifications = await AsyncStorage.getItem("notifications");
         const savedDarkMode = await AsyncStorage.getItem("darkMode");
+        const savedUtMode = await AsyncStorage.getItem("utMode");
 
         // Check if the saved values are valid before parsing
         if (savedNotifications !== null && savedNotifications !== undefined) {
@@ -36,6 +37,12 @@ export default function SettingsScreen() {
           setDarkMode(JSON.parse(savedDarkMode));
         } else {
           setDarkMode(false); // default to false if not set
+        }
+
+        if (savedUtMode !== null && savedUtMode !== undefined) {
+          setUsabilityTestingMode(JSON.parse(savedUtMode));
+        } else {
+          setUsabilityTestingMode(false); //default to false if not set
         }
       } catch (error) {
         console.error("Error loading settings:", error);
@@ -107,20 +114,6 @@ export default function SettingsScreen() {
           <Text style={styles.settingText}>{t("Account details")}</Text>
           <FontAwesome5 name="chevron-right" size={16} color="#912338" />
         </TouchableOpacity>
-
-        {/* Usability Testing Toggle */}
-        <TouchableOpacity
-            style={styles.settingOption}
-            onPress={() => {
-                usabilityTestingMode = toggleClarity(usabilityTestingMode);
-            }}
-            testID="usability-testing-toggle-button"
-        >
-            {/* TODO */}
-            <FontAwesome5 name="usability-testing" size={18} color="#912338" />
-            <Text style={styles.settingText}>{t("Usability Testing")}</Text>
-            <FontAwesome5 name="chevron-right" size={16} color="#912338" />
-        </TouchableOpacity>
         
         {/* Support */}
         <TouchableOpacity
@@ -132,6 +125,24 @@ export default function SettingsScreen() {
           <Text style={styles.settingText}>{t("Support")}</Text>
           <FontAwesome5 name="chevron-right" size={16} color="#912338" />
         </TouchableOpacity>
+
+        {/* Usability Testing Toggle */}
+        <View style={styles.settingOption} testID="usability-testing-toggle-button">
+          <FontAwesome5 name="eye" size={18} color="#912338" />
+          <Text style={styles.settingText}>{t("Usability Testing Mode")}</Text>
+          <Switch
+            value={usabilityTestingMode}
+            onValueChange={(value) => {
+              setUsabilityTestingMode(value);
+              saveSetting("utMode", value);
+              toggleClarity(value);
+              if(!value){
+                Alert.alert("Warning", "The CU-MapNav App needs to be restarted to fully exit Clarity usability testing. This only pauses Clarity.");
+              }
+            }}
+            testID="usability-testing-switch"
+          />
+        </View>
 
         {/* Logout */}
         <TouchableOpacity

--- a/expo-app/app/screens/Settings/SettingsScreen.tsx
+++ b/expo-app/app/screens/Settings/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import SettingsHeader from "../../components/Settings/SettingsHeader";
 import BottomNavigation from "../../components/BottomNavigation/BottomNavigation";
 import LanguageSelector from "@/app/components/LanguagePicker/LanguagePicker";
 import { useTranslation } from "react-i18next";
+import { toggleClarity } from "../../services/Clarity/ClarityService.ts";
 
 export default function SettingsScreen() {
   const { t } = useTranslation("SettingsScreen");
@@ -16,6 +17,7 @@ export default function SettingsScreen() {
 
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const [usabilityTestingMode, setUsabilityTestingMode] = useState(false);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -106,6 +108,20 @@ export default function SettingsScreen() {
           <FontAwesome5 name="chevron-right" size={16} color="#912338" />
         </TouchableOpacity>
 
+        {/* Usability Testing Toggle */}
+        <TouchableOpacity
+            style={styles.settingOption}
+            onPress={() => {
+                usabilityTestingMode = toggleClarity(usabilityTestingMode);
+            }}
+            testID="usability-testing-toggle-button"
+        >
+            {/* TODO */}
+            <FontAwesome5 name="usability-testing" size={18} color="#912338" />
+            <Text style={styles.settingText}>{t("Usability Testing")}</Text>
+            <FontAwesome5 name="chevron-right" size={16} color="#912338" />
+        </TouchableOpacity>
+        
         {/* Support */}
         <TouchableOpacity
           style={styles.settingOption}

--- a/expo-app/app/screens/Settings/SettingsScreen.tsx
+++ b/expo-app/app/screens/Settings/SettingsScreen.tsx
@@ -138,6 +138,8 @@ export default function SettingsScreen() {
               toggleClarity(value);
               if(!value){
                 Alert.alert("Warning", "The CU-MapNav App needs to be restarted to fully exit Clarity usability testing. This only pauses Clarity.");
+              }else{
+                Alert.alert("Suggested Tasks", "- Navigate to the home screen\n- View both campus maps\n- View shuttle bus schedule\n- Get directions to your next class\n- Get directions to a room/building of choice");//steps to be defined
               }
             }}
             testID="usability-testing-switch"

--- a/expo-app/app/screens/Settings/__tests__/SettingsScreen.test.tsx
+++ b/expo-app/app/screens/Settings/__tests__/SettingsScreen.test.tsx
@@ -7,6 +7,14 @@ const mockSignOut = jest.fn();
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
 
+jest.mock("@microsoft/react-native-clarity", () => ({
+  intialize: jest.fn(),
+  pause: jest.fn(), 
+  resume: jest.fn(), 
+  getCurrentSessionUrl: jest.fn(), 
+  sendCustomEvent: jest.fn(),
+}))
+
 jest.mock("@react-native-async-storage/async-storage", () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),

--- a/expo-app/app/screens/Settings/__tests__/SettingsScreen.test.tsx
+++ b/expo-app/app/screens/Settings/__tests__/SettingsScreen.test.tsx
@@ -10,6 +10,7 @@ const mockReplace = jest.fn();
 jest.mock("@microsoft/react-native-clarity", () => ({
   intialize: jest.fn(),
   pause: jest.fn(), 
+  isPaused: jest.fn(),
   resume: jest.fn(), 
   getCurrentSessionUrl: jest.fn(), 
   sendCustomEvent: jest.fn(),
@@ -126,10 +127,11 @@ describe("SettingsScreen", () => {
     expect(mockPush).toHaveBeenCalledWith("/screens/Settings/SupportScreen");
   });
 
-  it("loads saved notification and dark mode settings from AsyncStorage", async () => {
+  it("loads saved notification, dark mode and usability testing mode settings from AsyncStorage", async () => {
     (AsyncStorage.getItem as jest.Mock).mockImplementation((key) => {
       if (key === "notifications") return Promise.resolve("true");
       if (key === "darkMode") return Promise.resolve("false");
+      if (key === "utMode") return Promise.resolve("false");
       return Promise.resolve(null);
     });
 
@@ -137,6 +139,7 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(getByTestId("notifications-switch").props.value).toBe(true);
       expect(getByTestId("dark-mode-switch").props.value).toBe(false);
+      expect(getByTestId("usability-testing-switch").props.value).toBe(false);
     });
   });
 
@@ -147,4 +150,16 @@ describe("SettingsScreen", () => {
     expect(mockConsoleLog).toHaveBeenCalledWith("Delete Account");
     mockConsoleLog.mockRestore();
   });
+
+  it("toggles the usability testing mode switch and saves setting", async () => {
+      const { getByTestId } = render(<SettingsScreen />);
+      const switchElement = getByTestId("usability-testing-switch");
+      
+      fireEvent(switchElement, "valueChange", true);
+      fireEvent(switchElement, "valueChange", false);
+
+      await waitFor(() => expect(AsyncStorage.setItem).toHaveBeenCalledWith("utMode","true"));
+      await waitFor(() => expect(AsyncStorage.setItem).toHaveBeenCalledWith("utMode","false"));
+  });
+
 });

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -15,7 +15,7 @@ const clarityProjectId = Constants.expoConfig?.extra?.clarityProjectId;
 // Initialize Clarity Usability Testing Session
 export function runClarity(config = clarityDefaultConfig): Promise<boolean>{
     try{
-        if(Clarity.isPaused){
+        if(isClarityPaused()){
             resumeClarity();
         }
         Clarity.initialize(clarityProjectId, config);
@@ -42,10 +42,10 @@ export function resumeClarity(){
 }
 
 // Get Clarity Usability Testing Session Recording
-export function getClarityUrl(): string{
-    Clarity.getCurrentSessionUrl()
+export function getClarityUrl(): Promise<string>{
+    return Clarity.getCurrentSessionUrl()
         .then((url)=>{
-            return url || "could not find url";
+            return url;
         });
 }
 
@@ -56,14 +56,15 @@ export function stopClarity(){
 }
 
 // Send a custom event to Clarity
-export function sendCustomEventToClarity(event: string){
+export function sendCustomEventToClarity(event: string): Promise<boolean>{
     try{
-        if(event == null || event.length == -1){
+        if(event == null || event.length < 1){
             throw new Error('An empty string is an invalid event for usability testing');
         }
-        Clarity.sendCustomEvent(event);
+        return Clarity.sendCustomEvent(event);
     }catch(error){
         console.error(error);
+        return false;
     }
 }
 

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -5,12 +5,20 @@ import * as Clarity from '@microsoft/react-native-clarity';
 
 // Default config
 const clarityDefaultConfig = {
-  logLevel: Clarity.LogLevel.Verbose
+  //logLevel: Clarity.LogLevel.Verbose
 };
 
+// Project ID set in environment variable
+const clarityProjectId = process.env.CLARITY_PROJECT_ID;
+
 // Initialize Clarity Usability Testing Session
-export function runClarity(projectId: string, config = clarityDefaultConfig){
-    Clarity.initialize(projectId, config);
+export function runClarity(config = clarityDefaultConfig){
+    try{
+        Clarity.initialize(clarityProjectId, config);
+    }catch(error){
+        console.error(error);
+    }
+    
 }
 
 // Pause Clarity Usability Testing Session
@@ -24,13 +32,14 @@ export function resumeClarity(){
 }
 
 // Get Clarity Usability Testing Session Recording
-export function getClarityUrl(): string?{
+export function getClarityUrl(): string{
     Clarity.getCurrentSessionUrl()
         .then((url)=>{
             return url || "could not find url";
         });
 }
 
+// REMOVE, not supported by clarity
 // Stop Clarity Recording
 export function stopClarity(){
     Clarity.stop();
@@ -51,13 +60,12 @@ export function sendCustomEventToClarity(event: string){
 
 
 // Toggle
-export function toggleClarity(clarityIsOn: boolean, projectId: string, config = clarityDefaultConfig){
+export function toggleClarity(clarityIsOn: boolean, config = clarityDefaultConfig){
     if(clarityIsOn){
-        runClarity(projectId, config);
+        runClarity(config);
         clarityIsOn = false;
     }else{
-        stopClarity();
+        pauseClarity();
         clarityIsOn = true;
     }
-    return clarityIsOn;
 }

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -16,14 +16,14 @@ const clarityProjectId = Constants.expoConfig?.extra?.clarityProjectId;
 export function runClarity(config = clarityDefaultConfig): Promise<boolean>{
     try{
         if(isClarityPaused()){
-            resumeClarity();
+            Clarity.resume();
         }
         Clarity.initialize(clarityProjectId, config);
     }catch(error){
         console.error(error);
         return false;
     }
-    return true;    
+    return true;
 }
 
 // Pause Clarity Usability Testing Session
@@ -36,23 +36,12 @@ export function isClarityPaused(): Promise<boolean>{
     return Clarity.isPaused();
 }
 
-// Resume Clarity Usability Testing Session
-export function resumeClarity(){
-    Clarity.resume();
-}
-
 // Get Clarity Usability Testing Session Recording
 export function getClarityUrl(): Promise<string>{
     return Clarity.getCurrentSessionUrl()
         .then((url)=>{
             return url;
         });
-}
-
-// REMOVE, not supported by clarity
-// Stop Clarity Recording
-export function stopClarity(){
-    Clarity.stop();
 }
 
 // Send a custom event to Clarity

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -13,9 +13,9 @@ const clarityDefaultConfig = {
 const clarityProjectId = Constants.expoConfig?.extra?.clarityProjectId;
 
 // Initialize Clarity Usability Testing Session
-export function runClarity(config = clarityDefaultConfig): Promise<boolean>{
+export async function runClarity(config = clarityDefaultConfig): Promise<boolean>{
     try{
-        if(isClarityPaused()){
+        if(await isClarityPaused()){
             Clarity.resume();
         }else{
             Clarity.initialize(clarityProjectId, config);
@@ -38,20 +38,20 @@ export function isClarityPaused(): Promise<boolean>{
 }
 
 // Get Clarity Usability Testing Session Recording
-export function getClarityUrl(): Promise<string>{
-    return Clarity.getCurrentSessionUrl()
-        .then((url)=>{
-            return url;
-        });
+export async function getClarityUrl(): Promise<string>{
+    const url = await Clarity.getCurrentSessionUrl();
+    if (!url)
+        console.warn("Attempting to retrieve clarity URL without a session");
+    return url ?? "";
 }
 
 // Send a custom event to Clarity
-export function sendCustomEventToClarity(event: string): Promise<boolean>{
+export async function sendCustomEventToClarity(event: string): Promise<boolean>{
     try{
         if(event == null || event.length < 1){
             throw new Error('An empty string is an invalid event for usability testing');
         }
-        return Clarity.sendCustomEvent(event);
+        return await Clarity.sendCustomEvent(event);
     }catch(error){
         console.error(error);
         return false;

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -14,8 +14,9 @@ const clarityProjectId = Constants.expoConfig?.extra?.clarityProjectId;
 
 // Initialize Clarity Usability Testing Session
 export async function runClarity(config = clarityDefaultConfig): Promise<boolean>{
+    const isPaused = await isClarityPaused();
     try{
-        if(await isClarityPaused()){
+        if(isPaused){
             Clarity.resume();
         }else{
             Clarity.initialize(clarityProjectId, config);

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -1,3 +1,6 @@
+/*
+ * See npm package details here: https://www.npmjs.com/package/@microsoft/react-native-clarity
+ */
 import * as Clarity from '@microsoft/react-native-clarity';
 
 // Default config
@@ -47,3 +50,14 @@ export function sendCustomEventToClarity(event: string){
 }
 
 
+// Toggle
+export function toggleClarity(clarityIsOn: boolean, projectId: string, config = clarityDefaultConfig){
+    if(clarityIsOn){
+        runClarity(projectId, config);
+        clarityIsOn = false;
+    }else{
+        stopClarity();
+        clarityIsOn = true;
+    }
+    return clarityIsOn;
+}

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -1,0 +1,49 @@
+import * as Clarity from '@microsoft/react-native-clarity';
+
+// Default config
+const clarityDefaultConfig = {
+  logLevel: Clarity.LogLevel.Verbose
+};
+
+// Initialize Clarity Usability Testing Session
+export function runClarity(projectId: string, config = clarityDefaultConfig){
+    Clarity.initialize(projectId, config);
+}
+
+// Pause Clarity Usability Testing Session
+export function pauseClarity(){
+    Clarity.pause();
+}
+
+// Resume Clarity Usability Testing Session
+export function resumeClarity(){
+    Clarity.resume();
+}
+
+// Get Clarity Usability Testing Session Recording
+export function getClarityUrl(): string?{
+    Clarity.getCurrentSessionUrl()
+        .then((url)=>{
+            return url || "could not find url";
+        });
+}
+
+// Stop Clarity Recording
+export function stopClarity(){
+    Clarity.stop();
+}
+
+
+// Send a custom event to Clarity
+export function sendCustomEventToClarity(event: string){
+    try{
+        if(event == null || event.length == -1){
+            throw new Error('An empty string is an invalid event for usability testing');
+        }
+        Clarity.sendCustomEvent(event);
+    }catch(error){
+        console.error(error);
+    }
+}
+
+

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -17,8 +17,9 @@ export function runClarity(config = clarityDefaultConfig): Promise<boolean>{
     try{
         if(isClarityPaused()){
             Clarity.resume();
+        }else{
+            Clarity.initialize(clarityProjectId, config);
         }
-        Clarity.initialize(clarityProjectId, config);
     }catch(error){
         console.error(error);
         return false;

--- a/expo-app/app/services/Clarity/ClarityService.ts
+++ b/expo-app/app/services/Clarity/ClarityService.ts
@@ -2,6 +2,7 @@
  * See npm package details here: https://www.npmjs.com/package/@microsoft/react-native-clarity
  */
 import * as Clarity from '@microsoft/react-native-clarity';
+import Constants from 'expo-constants';
 
 // Default config
 const clarityDefaultConfig = {
@@ -9,21 +10,30 @@ const clarityDefaultConfig = {
 };
 
 // Project ID set in environment variable
-const clarityProjectId = process.env.CLARITY_PROJECT_ID;
+const clarityProjectId = Constants.expoConfig?.extra?.clarityProjectId;
 
 // Initialize Clarity Usability Testing Session
-export function runClarity(config = clarityDefaultConfig){
+export function runClarity(config = clarityDefaultConfig): Promise<boolean>{
     try{
+        if(Clarity.isPaused){
+            resumeClarity();
+        }
         Clarity.initialize(clarityProjectId, config);
     }catch(error){
         console.error(error);
+        return false;
     }
-    
+    return true;    
 }
 
 // Pause Clarity Usability Testing Session
 export function pauseClarity(){
     Clarity.pause();
+}
+
+// Check if Clarity Usability Testing Session is paused
+export function isClarityPaused(): Promise<boolean>{
+    return Clarity.isPaused();
 }
 
 // Resume Clarity Usability Testing Session
@@ -44,7 +54,6 @@ export function getClarityUrl(): string{
 export function stopClarity(){
     Clarity.stop();
 }
-
 
 // Send a custom event to Clarity
 export function sendCustomEventToClarity(event: string){

--- a/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
+++ b/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
@@ -1,0 +1,84 @@
+import * as ClarityService from '../ClarityService.ts'
+
+jest.mock("@microsoft/react-native-clarity", () =>({
+    expoConfig: {
+        extra:{
+            "clarityProjectId": "mock-project-id",
+        },
+    },
+    initialize: jest.fn().mockReturnValue()
+                .mockReturnValueOnce()
+                .mockReturnValueOnce()
+                .mockImplementation(()=>{throw new Error();}),
+    resume: jest.fn().mockReturnValue(),
+    getCurrentSessionUrl: jest.fn().mockResolvedValue()
+                            .mockImplementationOnce(() => Promise.resolve("mocked-clarity-url"))
+                            .mockResolvedValueOnce("could not find url"),
+    isPaused: jest.fn().mockReturnValue()
+                .mockReturnValueOnce(false)
+                .mockReturnValueOnce(true),
+    sendCustomEvent: jest.fn().mockReturnValue()
+                                .mockReturnValueOnce(true)
+                                .mockReturnValueOnce(false),
+}));
+
+initialize = jest.fn() as jest.Mock<Promise<Response>>;
+getCurrentSessionUrl = jest.fn() as jestMock<Promise<Response>>;
+
+describe("Clarity Access and Controls", () => {
+
+    beforeEach(()=>{
+        (initialize as jest.Mock).mockClear();
+        (getCurrentSessionUrl as jest.Mock).mockClear();
+    });
+    
+    it("Initiliaze clarity or resume if paused and return false when error occurs", async ()=>{
+       const expectedSuccessResult: boolean = true;
+       const expectedFailedResult: boolean = false;
+       const mockConsoleError = jest.spyOn(console, "error").mockImplementation(()=>{});
+
+       const results: boolean = await ClarityService.runClarity();
+       const resultResume: boolean = await ClarityService.runClarity();
+       const resultError: boolean = await ClarityService.runClarity();
+
+       expect(results).toBe(expectedSuccessResult);
+       expect(resultResume).toBe(expectedSuccessResult);
+       expect(resultError).toBe(expectedFailedResult);
+       expect(mockConsoleError).toHaveBeenCalled();
+
+    });
+
+    it("Pause Clarity, check Clarity is paused and resume Clarity", async () => {
+        const expectedIsPausedResult: boolean = true;
+        const expectedIsNotPausedResult: boolean = false;
+
+        
+    });
+    
+    it("Get the Clarity url or no url found message", async () => {
+        const expectedUrlResponse: string = "mocked-clarity-url";
+        const expectedNoUrlResponse: string = "could not find url";
+        
+        const response: string = await ClarityService.getClarityUrl();
+        const noSessionResponse: string = await ClarityService.getClarityUrl();
+
+        expect(response).toBe(expectedUrlResponse);
+        expect(noSessionResponse).toBe(expectedNoUrlResponse);
+    });
+
+    it("Send custome events to Clarity", () => {
+        const mockConsoleError = jest.spyOn(console, "error").mockImplementation(()=>{});//mocking error appears unneeded
+        const expectedResultInvalidParamString: boolean = false;
+        const expectedResultValidParamString: boolean = true;
+
+        const resultValidString: boolean = ClarityService.sendCustomEventToClarity("a-valid-string");
+        const resultInvalidString: boolean = ClarityService.sendCustomEventToClarity("");
+        
+        expect(resultValidString).toBe(expectedResultValidParamString);
+        expect(resultInvalidString).toBe(expectedResultInvalidParamString);
+        expect(mockConsoleError).toHaveBeenCalled();
+
+    });
+
+});
+

--- a/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
+++ b/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
@@ -14,7 +14,7 @@ jest.mock("@microsoft/react-native-clarity", () =>({
                 .mockImplementation(()=>{throw new Error();}),
     getCurrentSessionUrl: jest.fn().mockResolvedValue()
                             .mockImplementationOnce(() => Promise.resolve("mocked-clarity-url"))
-                            .mockResolvedValueOnce("could not find url"),
+                            .mockResolvedValueOnce(),
     isPaused: jest.fn().mockReturnValue()
                 .mockReturnValueOnce(false)
                 .mockReturnValueOnce(true)
@@ -59,22 +59,24 @@ describe("Clarity Access and Controls", () => {
     
     it("Get the Clarity url or no url found message", async () => {
         const expectedUrlResponse: string = "mocked-clarity-url";
-        const expectedNoUrlResponse: string = "could not find url";
+        const expectedNoUrlResponse: string = "";
+        const mockConsoleWarning = jest.spyOn(console, "warn").mockImplementation(()=>{});
         
         const response: string = await ClarityService.getClarityUrl();
         const noSessionResponse: string = await ClarityService.getClarityUrl();
 
         expect(response).toBe(expectedUrlResponse);
         expect(noSessionResponse).toBe(expectedNoUrlResponse);
+        expect(mockConsoleWarning).toHaveBeenCalled();
     });
 
-    it("Send custome events to Clarity", () => {
+    it("Send custome events to Clarity", async () => {
         const mockConsoleError = jest.spyOn(console, "error").mockImplementation(()=>{});//mocking error appears unneeded
         const expectedResultInvalidParamString: boolean = false;
         const expectedResultValidParamString: boolean = true;
 
-        const resultValidString: boolean = ClarityService.sendCustomEventToClarity("a-valid-string");
-        const resultInvalidString: boolean = ClarityService.sendCustomEventToClarity("");
+        const resultValidString: boolean = await ClarityService.sendCustomEventToClarity("a-valid-string");
+        const resultInvalidString: boolean = await ClarityService.sendCustomEventToClarity("");
         
         expect(resultValidString).toBe(expectedResultValidParamString);
         expect(resultInvalidString).toBe(expectedResultInvalidParamString);

--- a/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
+++ b/expo-app/app/services/Clarity/__tests__/ClarityService.test.ts
@@ -8,14 +8,16 @@ jest.mock("@microsoft/react-native-clarity", () =>({
     },
     initialize: jest.fn().mockReturnValue()
                 .mockReturnValueOnce()
+                .mockReturnValueOnce(),
+    resume: jest.fn().mockReturnValue()
                 .mockReturnValueOnce()
                 .mockImplementation(()=>{throw new Error();}),
-    resume: jest.fn().mockReturnValue(),
     getCurrentSessionUrl: jest.fn().mockResolvedValue()
                             .mockImplementationOnce(() => Promise.resolve("mocked-clarity-url"))
                             .mockResolvedValueOnce("could not find url"),
     isPaused: jest.fn().mockReturnValue()
                 .mockReturnValueOnce(false)
+                .mockReturnValueOnce(true)
                 .mockReturnValueOnce(true),
     sendCustomEvent: jest.fn().mockReturnValue()
                                 .mockReturnValueOnce(true)

--- a/expo-app/package-lock.json
+++ b/expo-app/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/vector-icons": "^14.0.4",
         "@mapbox/polyline": "^1.2.1",
         "@mappedin/react-native-sdk": "^5.41.8",
+        "@microsoft/react-native-clarity": "^4.1.8",
         "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-native-community/datetimepicker": "8.2.0",
         "@react-native-community/slider": "4.5.5",
@@ -4215,6 +4216,25 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@microsoft/react-native-clarity": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/react-native-clarity/-/react-native-clarity-4.1.8.tgz",
+      "integrity": "sha512-4ufcPpVM81goRPoZrFqYT/K4bqMt3yypNCgZepM40SFv07j9vz69zdaQjds2KXPALZ+eBfk2IA01bHwmsmRNaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-svg": ">=14.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-svg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -23,6 +23,7 @@
     "@expo/vector-icons": "^14.0.4",
     "@mapbox/polyline": "^1.2.1",
     "@mappedin/react-native-sdk": "^5.41.8",
+    "@microsoft/react-native-clarity": "^4.1.8",
     "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-community/slider": "4.5.5",


### PR DESCRIPTION
### Overview
This PR adds a usability testing mode toggle in the settings view to activate and perform usability testing on demand, instead of relying on immediate initialization at launch. 
*N.B.* This  is a persistent setting and as such can be set before the usability testing session followed by a reboot and letting the user complete a set of given tasks

### Implementation Details
- **Clarity Service:** Integrated Clarity using a Facade design pattern.
- **UI Enhancements:** Added a settings switch button to activate usability testing mode.

---

### Screenshots
![usability-testing-mode](https://github.com/user-attachments/assets/a49fa996-c184-43a1-bd8d-81132da268c5)


### Testing & Documentation
- Added unit tests for the Clarity Service.
- Update and added unit tests for the Settings Screen.
