### PR TITLE
FT - Added Current Building Location Text

### DIFF
--- a/expo-app/app/components/CampusMap/CampusMap.tsx
+++ b/expo-app/app/components/CampusMap/CampusMap.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Modal,
 } from "react-native";
-import MapView, { Polygon, Polyline, Circle } from "react-native-maps";
+import MapView, { Polygon, Polyline, Circle, Marker } from "react-native-maps";
 import CustomMarker from "./CustomMarker";
 import { SGWBuildings, LoyolaBuildings } from "./data/buildingData";
 import { getDirections } from "@/app/utils/directions";
@@ -34,7 +34,7 @@ import { useTranslation } from "react-i18next";
 import RadiusAdjuster from "./RadiusAdjuster";
 import { getCustomMapStyle } from "./styles/MapStyles";
 import { calculateDistance, isPointInPolygon } from "@/app/utils/MapUtils";
-import { getFillColorWithOpacity } from "@/app/utils/helperFunctions";
+import { getFillColorWithOpacity, getCenterCoordinate } from "@/app/utils/helperFunctions";
 import IndoorMap from "@/app/components/IndoorNavigation/IndoorMap";
 
 interface CampusMapProps {
@@ -70,7 +70,7 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
   const buildings = campus === "SGW" ? SGWBuildings : LoyolaBuildings;
 
   const { t } = useTranslation("CampusMap");
-
+  
   useEffect(() => {
     let subscription: Location.LocationSubscription;
     (async () => {
@@ -304,7 +304,7 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
       );
     }
   };
-  
+
   return (
     <View style={styles.container}>
       <HamburgerWidget
@@ -374,6 +374,18 @@ const CampusMap = ({ pressedOptimizeRoute = false }: CampusMapProps) => {
                 testID={`building-marker-${building.id}-marker`}
               />
             ))}
+            {currentBuilding && (
+              <Marker
+                coordinate={getCenterCoordinate(currentBuilding.coordinates)}
+                anchor={{ x: 0.5, y: 0.5 }}
+                tracksViewChanges={false}
+                testID="current-building-marker"
+              >
+                <View style={styles.currentBuildingOverlay}>
+                  <Text style={styles.currentBuildingOverlayText}>Current Building</Text>
+                </View>
+              </Marker>
+            )}
           </>
         )}
 
@@ -602,6 +614,16 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontWeight: "600",
     fontSize: 16,
+  },
+  currentBuildingOverlay: {
+    backgroundColor: "rgba(0, 0, 0, 1)",
+    padding: 5,
+    borderRadius: 5,
+  },
+  currentBuildingOverlayText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "bold",
   },
 });
 

--- a/expo-app/app/components/CampusMap/__tests__/CampusMap.test.tsx
+++ b/expo-app/app/components/CampusMap/__tests__/CampusMap.test.tsx
@@ -80,6 +80,7 @@ jest.mock("@/app/utils/MapUtils", () => ({
 
 jest.mock("@/app/utils/helperFunctions", () => ({
   getFillColorWithOpacity: jest.fn(() => "rgba(0,0,0,0.5)"),
+  getCenterCoordinate: jest.fn((coordinates) => coordinates[0]),
 }));
 
 jest.mock("../modals/SearchModal", () => {

--- a/expo-app/app/utils/__tests__/helperFunction.test.tsx
+++ b/expo-app/app/utils/__tests__/helperFunction.test.tsx
@@ -1,4 +1,4 @@
-import { getFillColorWithOpacity } from "../helperFunctions";
+import { getFillColorWithOpacity, getCenterCoordinate } from "../helperFunctions";
 import {
   Building,
 } from "../types";
@@ -64,5 +64,38 @@ describe("getFillColorWithOpacity", () => {
     );
 
     expect(result).toBe("rgba(0, 0, 0, 0.4)");
+  });
+});
+
+
+describe("getCenterCoordinate", () => {
+  it("should return the center for two coordinates", () => {
+    const coordinates = [
+      { latitude: 0, longitude: 0 },
+      { latitude: 2, longitude: 2 },
+    ];
+    const expectedCenter = { latitude: 1, longitude: 1 };
+    const result = getCenterCoordinate(coordinates);
+    expect(result.latitude).toBeCloseTo(expectedCenter.latitude);
+    expect(result.longitude).toBeCloseTo(expectedCenter.longitude);
+  });
+
+  it("should return the same coordinate if only one coordinate is provided", () => {
+    const coordinates = [{ latitude: 5, longitude: -3 }];
+    const result = getCenterCoordinate(coordinates);
+    expect(result.latitude).toBeCloseTo(5);
+    expect(result.longitude).toBeCloseTo(-3);
+  });
+
+  it("should return the correct center for multiple coordinates", () => {
+    const coordinates = [
+      { latitude: 0, longitude: 0 },
+      { latitude: 4, longitude: 4 },
+      { latitude: 2, longitude: 2 },
+    ];
+    const expectedCenter = { latitude: 2, longitude: 2 };
+    const result = getCenterCoordinate(coordinates);
+    expect(result.latitude).toBeCloseTo(expectedCenter.latitude);
+    expect(result.longitude).toBeCloseTo(expectedCenter.longitude);
   });
 });

--- a/expo-app/app/utils/__tests__/helperFunction.test.tsx
+++ b/expo-app/app/utils/__tests__/helperFunction.test.tsx
@@ -83,8 +83,9 @@ describe("getCenterCoordinate", () => {
   it("should return the same coordinate if only one coordinate is provided", () => {
     const coordinates = [{ latitude: 5, longitude: -3 }];
     const result = getCenterCoordinate(coordinates);
-    expect(result.latitude).toBeCloseTo(5);
-    expect(result.longitude).toBeCloseTo(-3);
+    const expected = coordinates[0];
+    expect(result.latitude).toBeCloseTo(expected.latitude);
+    expect(result.longitude).toBeCloseTo(expected.longitude);
   });
 
   it("should return the correct center for multiple coordinates", () => {

--- a/expo-app/app/utils/helperFunctions.ts
+++ b/expo-app/app/utils/helperFunctions.ts
@@ -1,4 +1,4 @@
-import { Building, concordiaBurgendyColor, LocationType } from "./types";
+import { Building, concordiaBurgendyColor, Coordinates } from "./types";
 
 export const getFillColorWithOpacity = (
   building: Building,
@@ -51,3 +51,17 @@ const hexToRgba = (hex: string, alpha: number): string => {
 
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
+
+
+export const getCenterCoordinate = (coordinates: Coordinates[]): Coordinates => {
+    let latSum = 0;
+    let lonSum = 0;
+    coordinates.forEach((coord) => {
+      latSum += coord.latitude;
+      lonSum += coord.longitude;
+    });
+    return {
+      latitude: latSum / coordinates.length,
+      longitude: lonSum / coordinates.length,
+    };
+  };


### PR DESCRIPTION
## Overview

This PR adds a visual label indicating when a user is currently inside a building on the campus map. Previously, the only cue was a subtle color change, which could be unclear, this aims to improve clarity and orientation.


## Key Features

- Detects when user's current location is inside a building polygon
- Displays a visible label: **"Current Building”**
- Hides the label when the user exits the building area


## Implementation Details

- Used location boundary logic to check whether the user is inside a building polygon
- If so, renders a label positioned clearly over or near the respective building
- Text is styled for visibility and clarity
- No changes to map zoom/position logic; label floats independently

## Additional Notes

- Label text used: **“Current Building”** 


---


## Images
Inside Building Label
