### PR TITLE
FT (Usability Testing) -  Added a info notice on campus map use

### DIFF
--- a/expo-app/app/components/CampusMap/CampusMap.tsx
+++ b/expo-app/app/components/CampusMap/CampusMap.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/app/utils/helperFunctions";
 import IndoorMap from "@/app/components/IndoorNavigation/IndoorMap";
 import useLiveShuttleLocations from "@/app/hooks/useLiveShuttleLocations";
+import FontAwesome5 from "react-native-vector-icons/FontAwesome5";
 
 interface CampusMapProps {
   pressedOptimizeRoute?: boolean;
@@ -590,6 +591,22 @@ const CampusMap = ({
           </TouchableOpacity>
         )}
 
+<View
+        style={styles.campusMapInfoNotice}
+      >
+        <FontAwesome5
+          name="info"
+          size={18}
+          color="#666"
+          style={styles.infoNoticeIcon}
+        />
+        <Text
+          style={styles.campusMapInfoNoticeText}
+        >
+          {t("Tap on highlighted buildings to view options")}
+        </Text>
+      </View>
+
       <NavTab
         campus={campus}
         destination={destination}
@@ -656,6 +673,19 @@ const styles = StyleSheet.create({
     left: "50%",
     marginLeft: -25,
     marginTop: -25,
+  },
+  campusMapInfoNotice: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 0,
+    justifyContent: "center",
+  },
+  infoNoticeIcon: {
+    marginRight: 8,
+  },
+  campusMapInfoNoticeText: {
+    fontSize: 14,
+    color: "#666",
   },
   bottomButtonContainer: {
     position: "absolute",


### PR DESCRIPTION
## Overview

This PR aims to address comments made during the first rounds of usability testing. It does so by adding a visual info notice which acts as a hint to users who may have difficulty understanding the intention of highlighted buildings.


## Key Features

- Displays a visible info notice: **"Tap on highlighted buildings to view options”**

## Implementation Details

- Is specific to the *CampusMap* component
- Text is styled to avoid being intrusive yet helpful for confused users
- No functional changes made to the *CampusMap* component

## Additional Notes

- Label text used: **“Tap on highlighted buildings to view options”** 


---


## Images
Info notice on campus map
![ut-fix-building-selection-info](https://github.com/user-attachments/assets/a139e637-fc5c-49f5-95da-6eb7312d4a34)


